### PR TITLE
Lowered min_version to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        python-version: ["3.13"]
+        python-version: ["3.12"]
         include:
           - operating-system: ubuntu-latest
             path: ~/.cache/pip
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.12"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "docstring2json"
-version = "0.0.8"
+version = "0.0.9"
 description = "A tool to convert Google-style docstrings to JSON format"
 readme = "README.md"
 keywords = [
@@ -21,7 +21,7 @@ maintainers = [ { name = "Vladimir Iglovikov" } ]
 authors = [
   { name = "Vladimir Iglovikov", email = "iglovikov@gmail.com" },
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -29,6 +29,7 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Documentation",
@@ -61,7 +62,7 @@ docstring2json = [ "*.json", "templates/*.md", "templates/components/*.json.exam
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
-target-version = "py313"
+target-version = "py312"
 
 line-length = 120
 indent-width = 4
@@ -134,7 +135,7 @@ lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 lint.pydocstyle.convention = "google"
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.12"
 ignore_missing_imports = true
 follow_imports = "silent"
 warn_redundant_casts = true


### PR DESCRIPTION
## Summary by Sourcery

Lower the minimum Python version support from 3.13 to 3.12

New Features:
- Added Python 3.12 classifier

CI:
- Updated GitHub Actions workflow to use Python 3.12

Chores:
- Updated project configuration to target Python 3.12
- Bumped project version to 0.0.9